### PR TITLE
Bugfix/invalid field id on model  unknown

### DIFF
--- a/portal-addons/course_management/__manifest__.py
+++ b/portal-addons/course_management/__manifest__.py
@@ -14,7 +14,7 @@
     "category": "Uncategorized",
     "version": "0.1",
     # any module necessary for this one to work correctly
-    "depends": ["base"],
+    "depends": ["base", 'portal_student_management'],
     # always loaded
     "data": [
         "security/security.xml",

--- a/portal-addons/course_management/views/course_management_views.xml
+++ b/portal-addons/course_management/views/course_management_views.xml
@@ -34,7 +34,6 @@
                               </div>
                           </div>
                           <div class="col-4 o_kanban_primary_right">
-                              <!-- <button class="btn btn-primary" name="%(course_management.action_window)d"  type="action">View course</button> -->
                           </div>
                       </div>
                       <div class="row">


### PR DESCRIPTION
## FIX: External ID not found in the system: course_management.action_window, Invalid field 'id' on model '_unknown'

#### Current behavior before PR: 
    - get **External ID not found in the system: course_management.action_window** when installing course_management module. 
    - Gets **Invalid field 'id' on model '_unknown'** when enrolling student to a course.

#### Desired behavior after PR is merged:
   - Those erros should be gone. 

#### Changes Made: 
- Remove comment in course_management view. 
- Add portal_student_management to course_management depends

---

I confirm I have signed the CLA and read the PR guidelines at tech-portal
