### PR TITLE
[fix] remove ticket title, add computed field to show email of requester, api create ticket will receive student_emaill instead of student_id

### DIFF
--- a/portal-addons/feedback-ticket-management/controllers/controllers.py
+++ b/portal-addons/feedback-ticket-management/controllers/controllers.py
@@ -16,35 +16,43 @@ class FeedbackTicket(http.Controller):
     )
     def create_ticket(self, **kw):
         data = json.loads(http.request.httprequest.data.decode("utf-8"))
-        print("asd", data)
         if all(
             key in list(data.keys())
             for key in [
-                "ticket_title",
-                "student_id",
+                "student_email",
                 "ticket_category",
                 "course_id",
-                "lesson_url",
             ]
         ):
-            request.env["feedback_ticket"].sudo().create(
-                {
-                    "ticket_category": data.get("ticket_category"),
-                    "ticket_title": data.get("ticket_title"),
-                    "course_rel": data.get("course_id"),
-                    "lesson_url": data.get("lesson_url"),
-                    "ticket_description": data.get("ticket_description"),
-                    "ticket_requester": data.get("student_id"),
-                    "ticket_attachment": data.get("image"),
-                }
+            student_email = data.get("student_email")
+            student = (
+                request.env["portal.student"]
+                .sudo()
+                .search([("email", "=", student_email)])
             )
-            return http.request.make_json_response(
-                data={"message": "Your ticket has been generated!"}, status=200
-            )
+            if student:
+                request.env["feedback_ticket"].sudo().create(
+                    {
+                        "ticket_category": data.get("ticket_category"),
+                        "course_rel": data.get("course_id"),
+                        "lesson_url": data.get("lesson_url"),
+                        "ticket_description": data.get("ticket_description"),
+                        "ticket_requester": student.id,
+                        "ticket_attachment": data.get("image"),
+                    }
+                )
+                return http.request.make_json_response(
+                    data={"message": "Your ticket has been generated!"},
+                    status=200,
+                )
+            else:
+                return http.request.make_json_response(
+                    data={"message": "Student email not found!"}, status=400
+                )
         else:
             return http.request.make_json_response(
                 data={
-                    "message": "Please make sure your request header type is form-data and 'ticket_title', 'student_id', 'ticket_category', 'lesson_url', 'course_id' are included"
+                    "message": "Please make sure 'student_email', 'ticket_category' and 'course_id' are included in body request"
                 },
                 status=400,
             )

--- a/portal-addons/feedback-ticket-management/data/assign_email_template.xml
+++ b/portal-addons/feedback-ticket-management/data/assign_email_template.xml
@@ -11,7 +11,6 @@
             <field name="description">There is new ticket which is assigned to you</field>
             <field name="body_html" type="html">
                 <div style="width:100%">
-                        <h2>Ticket Title: <t t-out="object.ticket_title"></t></h2>
                         <h4>Dear <t t-out="object.ticket_assignee.name">,</t></h4>
                         <p>There is new ticket which is assigned to you. Go to Portal and check it out for further details.</p>
                         <p>Best regards,</p>

--- a/portal-addons/feedback-ticket-management/data/email_assignee_reminder_template.xml
+++ b/portal-addons/feedback-ticket-management/data/email_assignee_reminder_template.xml
@@ -11,7 +11,6 @@
             <field name="description">The ticket is assigned for days, please check and handle it</field>
             <field name="body_html" type="html">
                 <div style="width:100%">
-                        <h2>Ticket Title: <t t-out="object.ticket_title"></t></h2>
                         <h4>Dear <t t-out="object.ticket_assignee.name">,</t></h4>
                         <p>Your assigned ticket is pending for a long time . Please go to Portal to check it and proceed the next step.</p>
                         <p>Best regards,</p>

--- a/portal-addons/feedback-ticket-management/data/response_email_template.xml
+++ b/portal-addons/feedback-ticket-management/data/response_email_template.xml
@@ -11,7 +11,6 @@
             <field name="description">The ticket has been resolved. Make a response to requester</field>
             <field name="body_html" type="html">
                 <div style="width:100%">
-                        <h2>Ticket Title: <t t-out="object.ticket_title"></t></h2>
                         <h4>Dear <t t-out="object.ticket_requester.name">,</t></h4>
                         <p>Your feedback has been acknowledged and resolved. Please see the response below and proceed again</p>
                         <p>Reponse: <t t-out="object.ticket_response"></t></p>

--- a/portal-addons/feedback-ticket-management/views/tickets_view.xml
+++ b/portal-addons/feedback-ticket-management/views/tickets_view.xml
@@ -7,7 +7,6 @@
     <field name="arch" type="xml">
       <tree>
         <field name="ticket_number" />
-        <field name="ticket_title" />
         <field name="ticket_category" />
         <field name="ticket_assignee" />
         <field name="assign_to_you" />
@@ -25,11 +24,11 @@
         <form>
           <sheet>
               <h1><field name="ticket_number"/> </h1>
-              <h2><field name="ticket_title" placeholder="Ticket Title" /></h2>
               <group>
                 <group>
                   <field name="ticket_category" />
                   <field name="ticket_requester" />
+                  <field name="requester_email" />
                   <field name="ticket_assignee" />
                   <field name="course_rel" />
                   <field name="lesson_url" />
@@ -59,7 +58,6 @@
       <field name="arch" type="xml">
         <search>
           <field name="ticket_number" />
-          <field name="ticket_title" />
           <field name="ticket_assignee" />
           <field name="ticket_status" />
           <filter name="filter_personal_ticket" string="Your Tickets" domain="[('ticket_assignee', '=', uid)]" />
@@ -81,5 +79,4 @@
   <menuitem name="Feedback Ticket" id="feedback_ticket_management_menu_root"/>
   <menuitem name="All Tickets" id="feedback_ticket_management_list_all" parent="feedback_ticket_management_menu_root"
               action="feedback_ticket_management_action_window" />
-
 </odoo>


### PR DESCRIPTION
Title: Module: Ticket Feedback Management
Description:
- Add new computed field to show email of requester based on requester
- Remove ticket titlte
- API create ticket will receive student_email instead of student_id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
