### PR TITLE
fix: Update formular to calculate processing time

### DIFF
--- a/portal-addons/feedback-ticket-management/models/tickets.py
+++ b/portal-addons/feedback-ticket-management/models/tickets.py
@@ -2,6 +2,7 @@
 
 from odoo import models, fields, api
 from datetime import datetime
+import math
 
 
 class FeedbackTicket(models.Model):
@@ -194,11 +195,11 @@ class FeedbackTicket(models.Model):
             if ticket.ticket_status in ["waiting", "assigned", "in_progress"]:
                 process_time_temp = datetime.now() - ticket.created_at
                 ticket.warning_ticket = process_time_temp.days >= 2
-                ticket.processing_time = f"{process_time_temp.days} days {round(process_time_temp.seconds/3600)} hours"
+                ticket.processing_time = f"{process_time_temp.days} days {math.floor(process_time_temp.seconds/3600)} hours"
             elif ticket.ticket_status == "done" and ticket.complete_date:
                 ticket.warning_ticket = False
                 process_time_temp = ticket.complete_date - ticket.created_at
-                ticket.processing_time = f"{process_time_temp.days} days {round(process_time_temp.seconds/3000)} hours"
+                ticket.processing_time = f"{process_time_temp.days} days {math.floor(process_time_temp.seconds/3600)} hours"
 
     # assign datetime now to complete_date when ticket change status to done.
     @api.onchange("ticket_status")


### PR DESCRIPTION
## Description
- Current: when the time is 23.xx it will be round to 24 hours. So i replace round by math.floor to make it turn to 23 
### Notion Task
Please include a link to the notion task that this pull request is related to.
- [GEN-266](https://www.notion.so/68233b1464534b7d82e15867c27a7986?v=10575e2b484449898b0482071a4f1a35&p=4398ff1fbe4c43e3a5d993269671e659&pm=s)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires the database schema to be updated.
- [ ] This change create or update API endpoints.

## Checklist:
### General
- [x] I have performed a self-review of my own code.
- [x] This change has been tested locally to ensure it pass acceptance criterias.
- [x] All conflicts have been resolved.

### Database Changes (if applicable)
- [ ] I have added a migration file to update the database schema.
- [ ] I have updated the database schema ERD in this [link](https://drive.google.com/file/d/1PIRXgwItsAAR-MePVI0IXLRpVyzC3cU6/view?usp=sharing).
- [ ] I have log all change in the log file.
- [ ] All breaking changes have been communicated to the team and reviewed by PO/PM.

### API Changes (if applicable)
- [ ] I have updated the API Spec in this [link](https://docs.google.com/document/d/1WdZVLshSQK6OIrvA4hru1lXAjbDNo5J1AguMZvRaz2g/edit?usp=drive_link).
- [ ] I have update the Postman Collection in this [link](https://www.postman.com/universal-meteor-717123/workspace/manhattan/collection/2573019-7ceeff4f-4d49-405e-8a8c-6dc813d91bad?action=share&creator=2573019).


## Notes
Any other relevant information that would help the reviewer.
