### PR TITLE
feat: Add confirmation dialog to prompt saving unsaved changes

### DIFF
--- a/portal-addons/no_auto_save/__manifest__.py
+++ b/portal-addons/no_auto_save/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    "name": "No Auto Save",
+    "author": "khoansfx",
+    "category": "web",
+    "depends": ["base", "web"],
+    "data": [],
+    "assets": {
+        "web.assets_backend": [
+            "no_auto_save/static/src/js/no_auto_save.js"
+        ]
+    },
+    "installable": True,
+}

--- a/portal-addons/no_auto_save/static/src/js/no_auto_save.js
+++ b/portal-addons/no_auto_save/static/src/js/no_auto_save.js
@@ -1,0 +1,92 @@
+/** @odoo-module */
+import { useSetupView } from "@web/views/view_hook";
+import { FormController } from "@web/views/form/form_controller";
+import { ListController } from "@web/views/list/list_controller";
+import { FormStatusIndicator } from "@web/views/form/form_status_indicator/form_status_indicator";
+
+// Backup the original setup method of FormController
+const oldSetup = FormController.prototype.setup;
+// Backup the original onPagerUpdate method of FormController
+const oldOnPagerUpdated = FormController.prototype.onPagerUpdate;
+
+// Override the setup method of FormController
+const Formsetup = function () {
+    // Use the Odoo hook useSetupView to add custom behavior before leaving the view
+    useSetupView({
+        beforeLeave: () => {
+            // Check if the form has unsaved changes
+            if (this.model.root.isDirty) {
+                // Prompt the user to save changes
+                if (confirm("Do you want to save changes ?")) {
+                    // If confirmed, save the changes
+                    return this.model.root.save({noReload: true, stayInEdition: true});
+                } else {
+                    // If not confirmed, discard the changes
+                    this.model.root.discard();
+                    return true;
+                }
+            }
+        },
+    });
+    // Call the original setup method
+    const result = oldSetup.apply(this, arguments);
+    return result;
+};
+// Assign the new setup method to FormController
+FormController.prototype.setup = Formsetup;
+
+// Override the onPagerUpdate method of FormController
+const onPagerUpdate = await function () {
+    // Check for any changes in the form
+    this.model.root.askChanges();
+
+    // If there are unsaved changes
+    if (this.model.root.isDirty) {
+        // Prompt the user to save changes
+        if (confirm("Do you want to save changes ?")) {
+            // If confirmed, proceed with the original onPagerUpdate method
+            return oldOnPagerUpdated.apply(this, arguments);
+        }
+        // If not confirmed, discard the changes
+        this.model.root.discard();
+    }
+    // Proceed with the original onPagerUpdate method
+    return oldOnPagerUpdated.apply(this, arguments);
+};
+
+// Assign the new onPagerUpdate method to FormController
+FormController.prototype.onPagerUpdate = onPagerUpdate
+
+// Backup the original setup method of ListController
+const ListSuper = ListController.prototype.setup
+// Override the setup method of ListController
+const ListSetup = function () {
+    // Use the Odoo hook useSetupView to add custom behavior before leaving the view
+    useSetupView({
+        beforeLeave: () => {
+            // Get the current list and the edited record
+            const list = this.model.root;
+            const editedRecord = list.getEditedRecord;
+            // Check if the edited record is dirty (has unsaved changes)
+            if (editedRecord && editedRecord.isDirty) {
+                // Prompt the user to save changes
+                if (confirm('Do you want to save changes ?')) {
+                    // If confirmed, save the changes
+                    if (!list.unselectNRecord(true)) {
+                        throw new Error('Cannot save record');
+                    }
+                } else {
+                    // If not confirmed, discard the changes
+                    this.onClickDiscard();
+                    return true;
+                }
+            }
+        }
+    })
+    // Call the original setup method
+    const result = ListSuper.apply(this, arguments)
+    return result
+}
+
+// Assign the new setup method to ListController
+ListController.prototype.setup = ListSetup


### PR DESCRIPTION
## Description
When user made unsaved changes in form view or settings, there will be a dialog prompt to ask for confirmation.

### Notion Task
Please include a link to the notion task that this pull request is related to.
- [GEN-272](https://www.notion.so/68233b1464534b7d82e15867c27a7986?v=10575e2b484449898b0482071a4f1a35&p=10b85b3c4f2b4ca9920c9f992b995f85&pm=s)
- [GEN-301](https://www.notion.so/68233b1464534b7d82e15867c27a7986?v=10575e2b484449898b0482071a4f1a35&p=5666a7e4ff1d4b47ab74c972ad513ae8&pm=s)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires the database schema to be updated.
- [ ] This change create or update API endpoints.

## Checklist:
### General
- [x] I have performed a self-review of my own code.
- [x] This change has been tested locally to ensure it pass acceptance criterias.
- [x] All conflicts have been resolved.

### Database Changes (if applicable)
- [ ] I have added a migration file to update the database schema.
- [ ] I have updated the database schema ERD in this [link](https://drive.google.com/file/d/1PIRXgwItsAAR-MePVI0IXLRpVyzC3cU6/view?usp=sharing).
- [ ] I have log all change in the log file.
- [ ] All breaking changes have been communicated to the team and reviewed by PO/PM.

### API Changes (if applicable)
- [ ] I have updated the API Spec in this [link](https://docs.google.com/document/d/1WdZVLshSQK6OIrvA4hru1lXAjbDNo5J1AguMZvRaz2g/edit?usp=drive_link).
- [ ] I have update the Postman Collection in this [link](https://www.postman.com/universal-meteor-717123/workspace/manhattan/collection/2573019-7ceeff4f-4d49-405e-8a8c-6dc813d91bad?action=share&creator=2573019).


## Notes
Any other relevant information that would help the reviewer.
