### PR TITLE
fix: fix rules service_key name

### DIFF
--- a/portal-addons/service_key/models/service_key.py
+++ b/portal-addons/service_key/models/service_key.py
@@ -82,17 +82,11 @@ class ServiceKeyConfiguration(models.Model):
                 raise exceptions.ValidationError(
                     "Already exists, name must be unique!"
                 )
-            if record.name and re.search(r"[^a-zA-Z0-9\s]", record.name):
+            if record.name and re.search(r"[^A-Z0-9_]", record.name):
                 raise exceptions.ValidationError(
-                    "Name cannot contain special characters, except space letters!"
+                    "All letters in the name must be uppercase and it cannot contain special characters, except underscore (_)"
                 )
-            if not record.name[0].isupper() or re.search(
-                r"\s([a-z])", record.name
-            ):
+            if re.search(r"\_{2,}", record.name):
                 raise exceptions.ValidationError(
-                    "The first letter of a word must be uppercase!"
-                )
-            if re.search(r"\s{2,}", record.name):
-                raise exceptions.ValidationError(
-                    "Only one space is allowed between words!"
+                    "Only one undrscore (_) is allowed between words!"
                 )


### PR DESCRIPTION
## Description
- Fix standard validate for name of service key:
  + It  must be at least 6 letters 
  + It can contain one underscore (_) between words 
  + It cannot contain special words, except underscore (_)
  + It must be unique
### Notion Task
- [GEN-349](https://www.notion.so/T-o-m-t-Standard-cho-Service-Key-Validate-theo-Standard-n-y-5818b99d5b784f3a8fec3e317473f830?pvs=4)
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires the database schema to be updated.
- [ ] This change create or update API endpoints.
## Checklist:
### General
- [x] I have performed a self-review of my own code.
- [x] This change has been tested locally to ensure it pass acceptance criterias.
- [x] All conflicts have been resolved.

### Database Changes (if applicable)
- [ ] I have added a migration file to update the database schema.
- [ ] I have updated the database schema ERD in this [link](https://drive.google.com/file/d/1PIRXgwItsAAR-MePVI0IXLRpVyzC3cU6/view?usp=sharing).
- [ ] I have log all change in the log file.
- [ ] All breaking changes have been communicated to the team and reviewed by PO/PM.

### API Changes (if applicable)
- [ ] I have updated the API Spec in this [link](https://docs.google.com/document/d/1WdZVLshSQK6OIrvA4hru1lXAjbDNo5J1AguMZvRaz2g/edit?usp=drive_link).
- [ ] I have update the Postman Collection in this [link](https://www.postman.com/universal-meteor-717123/workspace/manhattan/collection/2573019-7ceeff4f-4d49-405e-8a8c-6dc813d91bad?action=share&creator=2573019).

## Notes:
- I have finished fix rules for name 