### PR TITLE
fix: auto set student gender to unknown if not provided when import

### DIFF
--- a/portal-addons/portal_student_management/models/student.py
+++ b/portal-addons/portal_student_management/models/student.py
@@ -64,6 +64,15 @@ class Student(models.Model):
 
         return student_code
 
+    @api.model
+    def _gender_generator(self, student_dict):
+        gender = student_dict.get("gender")
+
+        if not gender:
+            gender = "unknown"
+
+        return gender
+
     def _generate_fixed_length_password(self, length):
         # Define the character set from which to generate the password
         characters = string.ascii_letters + string.digits + string.punctuation
@@ -146,6 +155,8 @@ class Student(models.Model):
         student_dict["student_code"] = self._student_code_generator(
             student_dict
         )
+
+        student_dict["gender"] = self._gender_generator(student_dict)
 
         if student_dict["email"] and self.env["portal.student"].search(
             [("email", "=", student_dict["email"])]


### PR DESCRIPTION
## Description
- Auto set default value of student gender to "unknown" if not provided any value when importing xlsx file.

### Notion Task
Please include a link to the notion task that this pull request is related to.
None

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires the database schema to be updated.
- [ ] This change create or update API endpoints.

## Checklist:
### General
- [ ] I have performed a self-review of my own code.
- [ ] This change has been tested locally to ensure it pass acceptance criterias.
- [ ] All conflicts have been resolved.

### Database Changes (if applicable)
- [ ] I have added a migration file to update the database schema.
- [ ] I have updated the database schema ERD in this [link](https://drive.google.com/file/d/1PIRXgwItsAAR-MePVI0IXLRpVyzC3cU6/view?usp=sharing).
- [ ] I have log all change in the log file.
- [ ] All breaking changes have been communicated to the team and reviewed by PO/PM.

### API Changes (if applicable)
- [ ] I have updated the API Spec in this [link](https://docs.google.com/document/d/1WdZVLshSQK6OIrvA4hru1lXAjbDNo5J1AguMZvRaz2g/edit?usp=drive_link).
- [ ] I have update the Postman Collection in this [link](https://www.postman.com/universal-meteor-717123/workspace/manhattan/collection/2573019-7ceeff4f-4d49-405e-8a8c-6dc813d91bad?action=share&creator=2573019).


## Notes
Any other relevant information that would help the reviewer.
