### PR TITLE
Fix: Criterion grading

### DIFF
--- a/portal-addons/learning_project/models/project_criterion_response.py
+++ b/portal-addons/learning_project/models/project_criterion_response.py
@@ -388,6 +388,11 @@ class ProjectCriterionResponse(models.Model):
                 if text_from_html(r.feedback).strip() == "":
                     raise UserError("Feedback cannot be empty.")
 
+                if not r.result or r.result == NOT_GRADED[0]:
+                    raise UserError(
+                        "Result must be in passed, did not pass, incomplete."
+                    )
+
                 r.write(
                     {"feedback": r.feedback, "result": r.result, "step": 3}
                 )

--- a/portal-addons/learning_project/views/project_criterion_response_views.xml
+++ b/portal-addons/learning_project/views/project_criterion_response_views.xml
@@ -82,7 +82,7 @@
                             </div>
                             <div class="preview_criterion_body">
                                 <div class="preview_criterion_feedback">
-                                    <field name="feedback" class="html_field pointer_events_none"/>
+                                    <field name="feedback" attrs="{'readonly': [('step','&gt;', 2)]}" class="html_field pointer_events_none"/>
                                 </div>
                                 <field name="specifications_description" readonly="1"/>
                             </div>


### PR DESCRIPTION
## Description
**Fix criterion grading:**

Before: 
- mentor can move to next step if grade result "not_graded". 
- mentor can modify feedback at preview step and latest step.

After: 
- prevent move to next step if criterion result is 'not_graded'.
- Can not modify criterion feedback at preview step and latest step.
