### PR TITLE
feat: add indicated final submit result when grading student's projects

### DIFF
--- a/portal-addons/learning_project/views/project_submission_views.xml
+++ b/portal-addons/learning_project/views/project_submission_views.xml
@@ -50,6 +50,7 @@
                         </group>
                         <group>
                             <field name="result" string="Result" widget="badge" write="false" decoration-success="result == 'passed'" decoration-danger="result == 'did_not_pass'" decoration-warning="result == 'unable_to_review'" />
+                            <field name="temp_result" decoration-success="temp_result == 'Passed'" decoration-danger="temp_result == 'Did not pass'"/>
                             <field name="submission_url" string="Submission URL" write="false" text="View File" widget="url" attrs="{'invisible':[('submission_url','==',False)]}"/>
                             <field name="submission_url" string="Submission URL" write="false" attrs="{'invisible':[('submission_url','!=',False)]}"/>
                             <field name="grading_status" readonly="1"/>


### PR DESCRIPTION
## Description
Add live indicated final result when grading student's projects

### Notion Task
Please include a link to the notion task that this pull request is related to.
- [GEN-565](https://www.notion.so/68233b1464534b7d82e15867c27a7986?v=10575e2b484449898b0482071a4f1a35&p=ed30f74a2e3040969849d01eacd3cc25&pm=s)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires the database schema to be updated.
- [ ] This change create or update API endpoints.

## Checklist:
### General
- [ ] I have performed a self-review of my own code.
- [ ] This change has been tested locally to ensure it pass acceptance criterias.
- [ ] All conflicts have been resolved.

### Database Changes (if applicable)
- [ ] I have added a migration file to update the database schema.
- [ ] I have updated the database schema ERD in this [link](https://drive.google.com/file/d/1PIRXgwItsAAR-MePVI0IXLRpVyzC3cU6/view?usp=sharing).
- [ ] I have log all change in the log file.
- [ ] All breaking changes have been communicated to the team and reviewed by PO/PM.

### API Changes (if applicable)
- [ ] I have updated the API Spec in this [link](https://docs.google.com/document/d/1WdZVLshSQK6OIrvA4hru1lXAjbDNo5J1AguMZvRaz2g/edit?usp=drive_link).
- [ ] I have update the Postman Collection in this [link](https://www.postman.com/universal-meteor-717123/workspace/manhattan/collection/2573019-7ceeff4f-4d49-405e-8a8c-6dc813d91bad?action=share&creator=2573019).


## Notes
Any other relevant information that would help the reviewer.
